### PR TITLE
Feature: Add support for the oEmbed plugin.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -14,6 +14,10 @@ class DatawrapperPlugin_PublishS3 extends DatawrapperPlugin {
             DatawrapperHooks::register(DatawrapperHooks::UNPUBLISH_FILES, array($this, 'unpublish'));
             DatawrapperHooks::register(DatawrapperHooks::GET_PUBLISHED_URL, array($this, 'getUrl'));
             DatawrapperHooks::register(DatawrapperHooks::GET_PUBLISH_STORAGE_KEY, array($this, 'getBucketName'));
+
+            if (class_exists('DatawrapperPlugin_Oembed')) {
+                DatawrapperHooks::register(DatawrapperPlugin_Oembed::GET_PUBLISHED_URL_PATTERN, array($this, 'getUrlPattern'));
+            }
         }
     }
 
@@ -67,6 +71,18 @@ class DatawrapperPlugin_PublishS3 extends DatawrapperPlugin {
             return $cfg['alias'] . '/' . $chart->getID() . '/' . $chart->getPublicVersion() . '/';
         }
         return '//' . $cfg['bucket'] . '.s3.amazonaws.com/' . $chart->getID() . '/' . $chart->getPublicVersion() . '/index.html';
+    }
+
+    /**
+     * Returns a regular expression that can match the URLs of charts published
+     * on S3
+     */
+    public function getUrlPattern() {
+        $cfg = $this->getConfig();
+        if (!empty($cfg['alias'])) {
+            return $cfg['alias'] . '\/(?<id>.+?)/(?:\d+)(?:[\/])?';
+        }
+        return 'http[s]?:\/\/' . $cfg['bucket'] . '.s3.amazonaws.com\/(?<id>.+?)\/(?:\d+)(?:[\/](?:index\.html)?)?';
     }
 
     /**


### PR DESCRIPTION
Hi,

I've added support for the oEmbed plug-in, by checking if the oEmbed-plugin-class exists (Is there a better way of knowing if a module is installed?).

The urls-patterns generated should match the urls generated by `getUrl()`.

Kind regards
Morten Fangel.
